### PR TITLE
Automatically bump the download url on release webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+DOWNLOAD_URL=https://github.com/bswinnerton/launchbar-github/releases/download/v0.2.6/github.lbaction.zip
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
-DOWNLOAD_URL=https://github.com/bswinnerton/launchbar-github/releases/download/v0.2.6/github.lbaction.zip
+GITHUB_WEBHOOK_SECRET=
+HEROKU_TOKEN=

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -8,9 +8,9 @@ module Webhooks
     skip_before_action :verify_authenticity_token
 
     def create
-      return_404 unless is_authenticated?
-      return_422 unless tag_name.present?
-      return_422 if is_prerelease?
+      return not_found unless is_authenticated?
+      return unprocessable_entity unless tag_name.present?
+      return unprocessable_entity if is_prerelease?
 
       if bump_download_url(tag_name)
         head 200, content_type: 'application/json'
@@ -21,11 +21,11 @@ module Webhooks
 
     private
 
-    def return_404
-      raise ActionController::RoutingError.new('Not Found')
+    def not_found
+      head 404, content_type: 'application/json'
     end
 
-    def return_422
+    def unprocessable_entity
       head 422, content_type: 'application/json'
     end
 

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -1,0 +1,76 @@
+require 'net/http'
+
+module Webhooks
+  class GithubController < ApplicationController
+    DIGEST = OpenSSL::Digest.new('sha1')
+    SECRET = ENV.fetch('GITHUB_WEBHOOK_SECRET')
+
+    skip_before_action :verify_authenticity_token
+
+    def create
+      return_404 unless is_authenticated?
+      return_422 unless tag_name.present?
+      return_422 if is_prerelease?
+
+      if bump_download_url(tag_name)
+        head 200, content_type: 'application/json'
+      else
+        head 500, content_type: 'application/json'
+      end
+    end
+
+    private
+
+    def return_404
+      raise ActionController::RoutingError.new('Not Found')
+    end
+
+    def return_422
+      head 422, content_type: 'application/json'
+    end
+
+    def is_authenticated?
+      request.headers.fetch('X-Hub-Signature') == signature
+    end
+
+    def signature
+      signature = OpenSSL::HMAC.hexdigest(DIGEST, SECRET, request_payload)
+      "sha1=#{signature}"
+    end
+
+    def request_payload
+      request.body.rewind
+      request.body.read
+    end
+
+    def is_prerelease?
+      params.dig('release', 'prerelease')
+    end
+
+    def tag_name
+      params.dig('release', 'tag_name')
+    end
+
+    def bump_download_url(tag_name)
+      uri = URI.parse('https://api.heroku.com/apps/launchbar-github/config-vars')
+
+      request_headers = {
+        'Accept': 'application/vnd.heroku+json; version=3',
+        'Authorization': "Bearer #{ENV.fetch('HEROKU_TOKEN')}",
+        'Content-Type': 'application/json',
+      }
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      heroku_request = Net::HTTP::Patch.new(uri.request_uri, request_headers)
+      heroku_request.body = { "DOWNLOAD_URL" => download_url }.to_json
+      heroku_response = http.request(heroku_request)
+
+      heroku_response.code == '200' ? true : false
+    end
+
+    def download_url
+      "https://github.com/bswinnerton/launchbar-github/releases/download/#{tag_name}/github.lbaction.zip"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   get '/install', to: redirect('/auth/github')
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/auth/failure', to: redirect('/')
+  post '/webhooks/github', to: 'webhooks/github#create'
 end


### PR DESCRIPTION
This pull request adds a new API endpoint: `POST /webhooks/github`, which when properly hit with a [`release` webhook event](https://developer.github.com/v3/activity/events/types/#releaseevent), an API request is made to Heroku to reset the `DOWNLOAD_URL` environment variable based on the tag name of the release.

This endpoint requires the `X-Hub-Signature` header to be an hmac digest of the payload, signed with a shared secret. 